### PR TITLE
Include source_code_uri to gemspec

### DIFF
--- a/payjp.gemspec
+++ b/payjp.gemspec
@@ -23,5 +23,8 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
-  s.require_paths = ['lib']
+  s.require_paths = ['lib']  
+  s.metadata = {
+    "source_code_uri" => "https://github.com/payjp/payjp-ruby",
+  }
 end


### PR DESCRIPTION
Can you show repository link on rubygems?
It is convenient if there is repository link on rubygems( https://rubygems.org/gems/payjp ).