### PR TITLE
レートリミットへの対応

### DIFF
--- a/test/test_data.rb
+++ b/test/test_data.rb
@@ -287,5 +287,14 @@ module Payjp
         }
       }
     end
+
+    def test_over_capacity_error
+      {
+        :error => {
+          :code => "over_capacity",
+          :type => "api_error"
+        }
+      }
+    end
   end
 end


### PR DESCRIPTION
### レートリミットへの対応
https://pay.jp/docs/guideline-rate-limit

Python版の実装を参考にしました。
https://github.com/payjp/payjp-python

###### PythonとRubyの違いについて:  https://www.ruby-lang.org/ja/documentation/ruby-from-other-languages/to-ruby-from-python/