### PR TITLE
3Dセキュア対応

### DIFF
--- a/lib/payjp/charge.rb
+++ b/lib/payjp/charge.rb
@@ -19,6 +19,11 @@ module Payjp
       refresh_from(response, opts)
     end
 
+    def tds_finish(params = {}, opts = {})
+      response, opts = request(:post, tds_finish_url, params, opts)
+      refresh_from(response, opts)
+    end
+
     private
 
     def refund_url
@@ -31,6 +36,10 @@ module Payjp
 
     def reauth_url
       url + '/reauth'
+    end
+
+    def tds_finish_url
+      url + '/tds_finish'
     end
   end
 end

--- a/lib/payjp/version.rb
+++ b/lib/payjp/version.rb
@@ -1,3 +1,3 @@
 module Payjp
-  VERSION = '0.0.9'
+  VERSION = '0.0.10'
 end

--- a/test/payjp/charge_test.rb
+++ b/test/payjp/charge_test.rb
@@ -91,5 +91,17 @@ module Payjp
       c.reauth
       assert_equal expired_at.to_i, c.expired_at
     end
+
+    should "charges should be three_d_secure finishable" do
+      @mock.expects(:get).never
+      @mock.expects(:post).with do |url, api_key, params|
+        url == "#{Payjp.api_base}/v1/charges/test_charge/tds_finish" && api_key.nil? && CGI.parse(params) == {}
+      end.once.returns(test_response({ :id => "test_charge", :paid => true, :captured => true }))
+
+      c = Payjp::Charge.new("test_charge")
+      c.tds_finish
+      assert c.paid
+      assert c.captured
+    end
   end
 end


### PR DESCRIPTION
[3Dセキュア完了エンドポイント](https://pay.jp/docs/api/#3d%E3%82%BB%E3%82%AD%E3%83%A5%E3%82%A2%E3%83%95%E3%83%AD%E3%83%BC%E3%82%92%E5%AE%8C%E4%BA%86%E3%81%99%E3%82%8B)へのリクエストメソッドを追加