### PR TITLE
rename statement_urls POST API useful method name

### DIFF
--- a/lib/payjp/statement.rb
+++ b/lib/payjp/statement.rb
@@ -2,14 +2,14 @@ module Payjp
   class Statement < APIResource
     include Payjp::APIOperations::List
 
-    def create_statement_urls(params = {}, opts = {})
-      response, opts = request(:post, create_statement_urls_url, params, opts)
+    def statement_urls(params = {}, opts = {})
+      response, opts = request(:post, statement_urls_url, params, opts)
       response
     end
 
     private
 
-    def create_statement_urls_url
+    def statement_urls_url
       url + '/statement_urls'
     end
   end

--- a/lib/payjp/version.rb
+++ b/lib/payjp/version.rb
@@ -1,3 +1,3 @@
 module Payjp
-  VERSION = '0.0.12'
+  VERSION = '0.0.13'
 end

--- a/test/payjp/statement_test.rb
+++ b/test/payjp/statement_test.rb
@@ -22,11 +22,11 @@ module Payjp
       assert statement.items[0].to_hash.has_key?(:tax_rate)
     end
 
-    should "create_statement_urls should be callable" do
+    should "statement_urls should be callable" do
       @mock.expects(:get).never
       @mock.expects(:post).once.returns(test_response({ :object => "statement_url", :url => 'https://pay.jp/_/statements/8f9ec721bc734dbcxxxxxxxxxxxxxxxx', :expires => 1476676539 }))
       c = Payjp::Statement.new('st_test')
-      response = c.create_statement_urls()
+      response = c.statement_urls()
       assert_equal response[:url], 'https://pay.jp/_/statements/8f9ec721bc734dbcxxxxxxxxxxxxxxxx'
     end
   end


### PR DESCRIPTION
## 概要

先日リリースしたstatementリソースのURL生成APIについて、他SDKとの兼ね合いや本SDK内の規則など鑑みて命名をシンプルにしたい。
本APIの本SDKからの利用は現時点でまだなく、ドキュメント記載もこれからのため、アナウンスなしで変更する。

cf. 参考となったtenant.application_urlsのAPI（create_application_urlsメソッド）は1加盟店の利用があるため変更は見送る。