### PR TITLE
ruby3系で動くように + CIビルドができない状態の2.3未満をCIビルド対象から外した

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ruby-version: [2.2, 2.3.0, 2.7.0, 3.3.6, jruby-9.2.17.0]
+        ruby-version: [2.7.0, 3.3.6, jruby-9.2.17.0]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ruby-version: [2.7.0, 3.3.6, jruby-9.2.17.0]
+        ruby-version: [2.3.0, 2.7.0, 3.3.6, jruby-9.2.17.0]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ruby-version: [2.0.0, 2.1, 2.2, 2.3.0, 2.7.0, 3.3.6, jruby-9.2.17.0]
+        ruby-version: [2.2, 2.3.0, 2.7.0, 3.3.6, jruby-9.2.17.0]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ruby-version: [2.0.0, 2.1, 2.2, 2.3.0, 2.7.0, jruby-9.2.17.0]
+        ruby-version: [2.0.0, 2.1, 2.2, 2.3.0, 2.7.0, 3.3.6, jruby-9.2.17.0]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/payjp.gemspec
+++ b/payjp.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('mocha', '~> 1.2.1')
   s.add_development_dependency('activesupport', ['< 5.0', '~> 4.2.7'])
-  s.add_development_dependency('test-unit', '~> 3.2.2')
-  s.add_development_dependency('rake', '~> 11.3.0')
+  s.add_development_dependency('test-unit', '~> 3.6.2')
+  s.add_development_dependency('rake', '>= 11.3.0')
   s.add_development_dependency('bundler', '>= 1.7.6')
 
   s.files = `git ls-files`.split("\n")


### PR DESCRIPTION
- ruby 3系でテストコマンド( `bundle exec rake test` )が動かない状態だったので関連ライブラリを更新
- 現在設定されているCIテスト対象のrubyバージョンが2.0.0, 2.1, 2.2で通らなかった
  - https://github.com/payjp/payjp-ruby/actions/runs/11808889750/job/32898245315#step:3:103
  - https://github.com/payjp/payjp-ruby/actions/runs/11811285295
- 大昔にEOLなのでテスト対象から外す https://www.ruby-lang.org/ja/downloads/branches/