### PR TITLE
Add base64 dependency to gemspec

### DIFF
--- a/payjp.gemspec
+++ b/payjp.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency('rest-client', '~> 2.0')
+  s.add_dependency('base64')
 
   s.add_development_dependency('mocha', '~> 1.2.1')
   s.add_development_dependency('activesupport', ['< 5.0', '~> 4.2.7'])
@@ -23,7 +24,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
-  s.require_paths = ['lib']  
+  s.require_paths = ['lib']
   s.metadata = {
     "source_code_uri" => "https://github.com/payjp/payjp-ruby",
   }


### PR DESCRIPTION
This pull request includes a minor change to the `payjp.gemspec` file, which adds a new dependency to the project.

* Added `base64` as a new dependency in the `payjp.gemspec` file.

fix https://github.com/payjp/payjp-ruby/issues/38