### PR TITLE
refactor: replace string initialization with String.new for clarity

### DIFF
--- a/lib/payjp/util.rb
+++ b/lib/payjp/util.rb
@@ -71,7 +71,7 @@ module Payjp
       # (from URI::RFC2396_Parser#escape)
       key.to_s.gsub(Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")) do
         us = $&
-        tmp = ''
+        tmp = String.new
         us.each_byte do |uc|
           tmp << sprintf('%%%02X', uc)
         end


### PR DESCRIPTION
This pull request includes a change to the `lib/payjp/util.rb` file to improve the `url_encode` method. The change replaces the initialization of a temporary string variable from an empty string to a new `String` object for better clarity and potential performance benefits.

* [`lib/payjp/util.rb`](diffhunk://#diff-938d0c82acdb933938e3d9462a1dcb037d267318f4cb2dda738abe0e1c937d18L74-R74): Modified the `url_encode` method to initialize the `tmp` variable using `String.new` instead of an empty string.

fix https://github.com/payjp/payjp-ruby/issues/39