### PR TITLE
update Ruby version matrix in GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ruby-version: [2.3, 2.7, 3.0, 3.1, 3.2, 3.3, jruby-9.2.17.0]
+        ruby-version: [2.3, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, jruby-9.2.17.0]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}


### PR DESCRIPTION
This pull request includes an update to the Ruby versions tested in the GitHub Actions workflow configuration. The change adds support for Ruby 3.4 to the matrix of Ruby versions.

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L11-R11): Added Ruby 3.4 to the list of versions tested in the matrix.